### PR TITLE
Added LP per MW text on curiosities

### DIFF
--- a/src/haven/Curiosity.java
+++ b/src/haven/Curiosity.java
@@ -42,6 +42,7 @@ public class Curiosity extends ItemInfo.Tip {
 	public BufferedImage tipimg() {
 		StringBuilder buf = new StringBuilder();
 		buf.append(String.format("Learning points: $col[192,192,255]{%s}\nMental weight: $col[255,192,255]{%d}\n", Utils.thformat(exp), mw));
+		buf.append(String.format("LP/MW: $col[255,255,192]{%s}\n", String.format("%.1f", (double) exp / mw)));
 		if (enc > 0) {
 			buf.append(String.format("Experience cost: $col[255,255,192]{%d}\n", enc));
 			buf.append(String.format("LP/XP: $col[255,255,192]{%s}\n", String.format("%.1f", (double) exp / enc)));


### PR DESCRIPTION
Now you can see how much Learning Points (LP) you gain per Mental Weight
(MW)